### PR TITLE
add custom repository url to allow forks to get w/ composer himself properly

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -36,6 +36,9 @@ sum=$(( $sum + $? ))
 if [[ $1 != *"victoire/victoire"* ]]; then
     revision=$(cd ../../../ && git rev-parse HEAD)
     branch=$(cd ../../../ && git rev-parse --abbrev-ref HEAD)
+    sed -i 's/"name": "victoire\/victoire",/"name": "victoire\/victoire",\
+    "repositories": [{"type": "vcs", "url": "${CIRCLE_REPOSITORY_URL}"}],/' composer.json
+
     php -d memory_limit=-1 /usr/local/bin/composer require $1:dev-$branch#$revision --prefer-dist
     sum=$(( $sum + $? ))
 fi
@@ -45,6 +48,7 @@ if [ -f ../../../Tests/dependencies.sh ]; then
 fi
 
 (cd Bundle/UIBundle/Resources/config/ && bower install)
+php Tests/App/bin/console --env=ci doctrine:database:create --no-debug && \
 php Tests/App/bin/console --env=ci doctrine:database:create --no-debug && \
 php Tests/App/bin/console --env=ci doctrine:schema:create --no-debug && \
 php Tests/App/bin/console --env=ci cache:clear --no-debug && \


### PR DESCRIPTION
Try to fork a widget and submit a PR and you'll get this error : 

```php
PHP Fatal error:  Uncaught Error: Class 'Victoire\Widget\{YourWidgetName}Bundle\VictoireWidget{YourWidgetName}Bundle' not found in /home/ubuntu/Widget{YourWidgetName}Bundle/Tests/Bundles.php:4
```

The incriminated line is the https://github.com/Victoire/test-suite/blob/1de04929f014ca31144daefbb36d229157458f59/dependencies.sh#L39

This PR will simply add the widget's fork repo url in the victoire's `composer.json` file to be able to bypass packagist and fetch the correct repo instead.